### PR TITLE
Fix a compilation issue with Starscream dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ def shared_pods
     pod 'ObjectMapper', '~> 1.2.0'
     pod 'AlamofireObjectMapper', '= 3.0.0'
     pod 'SwiftyJSON', '~> 2.3.2'
-    pod 'Starscream', '~> 1.1.3'
+    pod 'Starscream', '= 1.1.3'
     pod 'KeychainAccess', '~> 2.3.5'
     pod 'CocoaLumberjack/Swift', '~> 2.3.0'
 end

--- a/SparkSDK.podspec
+++ b/SparkSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.dependency 'ObjectMapper', '~> 1.2.0'
   s.dependency 'AlamofireObjectMapper', '= 3.0.0'
   s.dependency 'SwiftyJSON', '~> 2.3.2'
-  s.dependency 'Starscream', '~> 1.1.3'
+  s.dependency 'Starscream', '= 1.1.3'
   s.dependency 'KeychainAccess', '~> 2.3.5'
   s.dependency 'CocoaLumberjack/Swift', '~> 2.3.0'
 end


### PR DESCRIPTION
Replacing arrow with equal to prevent cocopods bringing version 1.1.4 instead of 1.1.3 for Starscream (which doesn't compile)