### PR TITLE
Reenabled SSL certificate validation 

### DIFF
--- a/Source/Phone/WebSocketService.swift
+++ b/Source/Phone/WebSocketService.swift
@@ -113,7 +113,6 @@ class WebSocketService: WebSocketDelegate {
         
         socket?.headers.unionInPlace(authorization)
         socket?.voipEnabled = true
-        socket?.disableSSLCertValidation = true
         socket?.delegate = self
         
         return socket


### PR DESCRIPTION
Presumably the SSL certificate validation was disabled at some point for testing reasons, or because the SDK was running against a non-production service without a valid certificate, but it should not be needed now, and represents a strong security concern.