### PR TITLE
Use minor version to lock for semantic versioning

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,12 +3,12 @@ platform :ios, '9.0'
 use_frameworks!
 
 def shared_pods
-	pod 'Alamofire', '~> 4.0.0'
-	pod 'ObjectMapper', '~> 2.0.0'
-	pod 'AlamofireObjectMapper', '~> 4.0.0'
-	pod 'SwiftyJSON', '~> 3.1.0'
-	pod 'Starscream', '~> 2.0.0'
-	pod 'KeychainAccess', '~> 3.0.0'
+	pod 'Alamofire', '~> 4.0'
+	pod 'ObjectMapper', '~> 2.0'
+	pod 'AlamofireObjectMapper', '~> 4.0'
+	pod 'SwiftyJSON', '~> 3.1'
+	pod 'Starscream', '~> 2.0'
+	pod 'KeychainAccess', '~> 3.0'
 end
 
 target 'SparkSDK' do

--- a/SparkSDK.podspec
+++ b/SparkSDK.podspec
@@ -12,10 +12,10 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'MediaEngine/Wme.framework'
   s.xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(PODS_ROOT)/SparkSDK/MediaEngine', 'ENABLE_BITCODE' => 'NO'}
   s.vendored_frameworks = "MediaEngine/Wme.framework"
-  s.dependency 'Alamofire', '~> 4.0.0'
-  s.dependency 'ObjectMapper', '~> 2.0.0'
-  s.dependency 'AlamofireObjectMapper', '~> 4.0.0'
-  s.dependency 'SwiftyJSON', '~> 3.1.0'
-  s.dependency 'Starscream', '~> 2.0.0'
-  s.dependency 'KeychainAccess', '~> 3.0.0'
+  s.dependency 'Alamofire', '~> 4.0'
+  s.dependency 'ObjectMapper', '~> 2.0'
+  s.dependency 'AlamofireObjectMapper', '~> 4.0'
+  s.dependency 'SwiftyJSON', '~> 3.1'
+  s.dependency 'Starscream', '~> 2.0'
+  s.dependency 'KeychainAccess', '~> 3.0'
 end


### PR DESCRIPTION
I edited `Podfile` and `SparkSDK.podspec` to lock on major version of the dependencies only. This way, SparkSDK becomes more flexible in the dependencies it requires. Note that a `pod update` would update Alamofire to version 4.5 or higher when there are no other constraints (e.g., another pod that requires Alamofire 4.4).