### PR TITLE
Open websocket for incoming calls when app is in background

### DIFF
--- a/Source/Phone/Phone.swift
+++ b/Source/Phone/Phone.swift
@@ -924,9 +924,9 @@ public class Phone {
 
 extension Notification.Name {
     /// A notification name for an incoming call in background.
-    static let incomingCallInBackground = Notification.Name("Cisco.SparkSDK.incomingCallInBackground")
+    public static let incomingCallInBackground = Notification.Name("Cisco.SparkSDK.incomingCallInBackground")
     /// A notification name for a declined call in background.
-    static let declinedCallInBackground = Notification.Name("Cisco.SparkSDK.declinedCallInBackground")
+    public static let declinedCallInBackground = Notification.Name("Cisco.SparkSDK.declinedCallInBackground")
 }
 
 extension NSNotification {

--- a/Source/Phone/Phone.swift
+++ b/Source/Phone/Phone.swift
@@ -836,6 +836,9 @@ public class Phone {
         NotificationCenter.default.addObserver(self, selector: #selector(self.onApplicationDidBecomeActive) , name: .UIApplicationDidBecomeActive, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.onApplicationDidEnterBackground) , name: .UIApplicationDidEnterBackground, object: nil)
         #endif
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(self.onIncomingCallInBackground) , name: .incomingCallInBackground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.onDeclinedCallInBackground) , name: .declinedCallInBackground, object: nil)
     }
     
     private func stopObserving() {
@@ -856,6 +859,16 @@ public class Phone {
     @objc func onApplicationDidEnterBackground() {
         SDKLogger.shared.info("Application did enter background")
         self.disconnectFromWebSocket()
+    }
+    
+    @objc func onIncomingCallInBackground() {
+        SDKLogger.shared.info("Application has an incoming call in background ")
+        connectToWebSocket()
+    }
+    
+    @objc func onDeclinedCallInBackground() {
+        SDKLogger.shared.info("Application has a declined call in background ")
+        disconnectFromWebSocket()
     }
     
     private func connectToWebSocket() {
@@ -907,4 +920,18 @@ public class Phone {
         
     }
     
+}
+
+extension Notification.Name {
+    /// A notification name for an incoming call in background.
+    static let incomingCallInBackground = Notification.Name("Cisco.SparkSDK.incomingCallInBackground")
+    /// A notification name for a declined call in background.
+    static let declinedCallInBackground = Notification.Name("Cisco.SparkSDK.declinedCallInBackground")
+}
+
+extension NSNotification {
+    /// Objective-C version of a notification name for an incoming call in background.
+    public static let incomingCallInBackground: NSString = Notification.Name.incomingCallInBackground.rawValue as NSString
+    /// Objective-C version of a notification name for a declined call in background.
+    public static let declinedCallInBackground: NSString = Notification.Name.declinedCallInBackground.rawValue as NSString
 }


### PR DESCRIPTION
To enable incoming calls when the application is in the background and smooth CallKit integration, we made some changes within the SparkSDK itself. Our use case is the following:

- Our application registers for PushKit VoIP push notifications as outlined in the Apple documentation about background calls here: https://developer.apple.com/documentation/pushkit
- When someone logs in to the SparkSDK in our app, we register a webhook on incoming calls
- When that person receives a call, the webhook notifies our backend of the incoming call, and we send a VoIP push notification to the person's device.
- We send the `onIncomingCallInBackground` notification through the `NotificationCenter` from within the app
- Our modifications in the SparkSDK pick up this notification, and the websocket is opened.
- We are now able to handle the call with the regular flow of the SDK.

We would like to know if either this implementation could be officially supported (by merging this PR or a modified version of it into the main repository), or whether there is a different flow for background calls that we should follow.